### PR TITLE
chore(deps): bump from

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,3 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.17](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.17) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.8](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.17](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.17) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.25](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.25
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.25
+  version: 0.0.41
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -17,3 +17,9 @@ dependencies:
   url: https://github.com/salaboy/fmtok8s-agenda
   version: 0.0.31
   versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31
+- host: github.com
+  owner: salaboy
+  repo: fmtok8s-api-gateway
+  url: https://github.com/salaboy/fmtok8s-api-gateway
+  version: 0.0.45
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.8
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.8
+  version: 0.0.17
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.17
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.44
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.16
+  version: 0.0.17

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.31
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.40
+  version: 0.0.41
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.44

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.41
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.44
+  version: 0.0.45
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.17


### PR DESCRIPTION
Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.44](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.44) to [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.45 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.16](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.16) to [0.0.17](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.17)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.17 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`