### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.19](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.42](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.42) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.46](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.32](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.32) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.43](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.43) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.20](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.20) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.33](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.20](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.20) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.33](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.44](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.44) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.19](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.21](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.21) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.34](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.34) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.45](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.45) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.19](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.46](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.21](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.21) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.34](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.34) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,4 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.45](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.45) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.56](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.56) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.43](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.43) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.33](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.42](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.42) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.46](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.32](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.32) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.44](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.44) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.34](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.34) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.18
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18
+  version: 0.0.19
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.31
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31
+  version: 0.0.32
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.32
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.33
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33
+  version: 0.0.34
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.34
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.20
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.20
+  version: 0.0.21
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.21
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.32
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.32
+  version: 0.0.33
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.43
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.43
+  version: 0.0.44
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.44
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.41
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41
+  version: 0.0.42
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.42
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.42
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.42
+  version: 0.0.43
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.43
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.44
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.44
+  version: 0.0.45
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.45
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.45
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45
+  version: 0.0.46
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19
+  version: 0.0.20
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.20
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.46
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46
+  version: 0.0.56
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.56

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.33
+  version: 0.0.34
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.44

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.45
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.46
+  version: 0.0.56
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.21

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.31
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.41
+  version: 0.0.42
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.46

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.46
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.20

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.46
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.20
+  version: 0.0.21

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.41
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.45
+  version: 0.0.46
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.19

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.45
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.18
+  version: 0.0.19

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.33
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.43
+  version: 0.0.44
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.46

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.34
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.44
+  version: 0.0.45
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.46

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.31
+  version: 0.0.32
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.42

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.32
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.42
+  version: 0.0.43
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.46

--- a/jnation-app/requirements.yaml
+++ b/jnation-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.32
+  version: 0.0.33
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.43


### PR DESCRIPTION
Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) to [0.0.56](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.56)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.56 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) to [0.0.45](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.45)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.45 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) to [0.0.21](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.21)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.21 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) to [0.0.34](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.34)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.34 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) to [0.0.44](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.44)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.44 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) to [0.0.20](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.20)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.20 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) to [0.0.33](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.33)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.33 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) to [0.0.43](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.43)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.43 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.31](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.31) to [0.0.32](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.32)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.32 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.41](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.41) to [0.0.42](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.42)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.42 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.45](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.45) to [0.0.46](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.46)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.46 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.18](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.18) to [0.0.19](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.19)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.19 --repo https://github.com/salaboy/fmtok8s-jnation-app.git`